### PR TITLE
Added syntax highlighting for 'dcmplx' which is a standard fortran conversion function

### DIFF
--- a/grammars/FortranModern.sublime-syntax
+++ b/grammars/FortranModern.sublime-syntax
@@ -1323,7 +1323,7 @@ contexts:
     - match: (?x:\b  (?i:present)  \b  (?=\s*\()  )
       scope: support.function.fortran
     # 2. Numerical functions
-    - match: (?x:\b  (?i:abs|aimag|aint|anint|cmplx|conjg|dble|dim|dprod|int|max|min|mod|nint|real|sign)  \b  (?=\s*\()  )
+    - match: (?x:\b  (?i:abs|aimag|aint|anint|dcmplx|cmplx|conjg|dble|dim|dprod|int|max|min|mod|nint|real|sign)  \b  (?=\s*\()  )
       scope: support.function.fortran
     - match: (?x:\b  (?i:ceiling|floor|modulo)  \b  (?=\s*\()  )
       scope: support.function.fortran


### PR DESCRIPTION
Just as dble(NUMBER) converts a number to double precision so does dcmplx(REALNUMBER,IMAGNUMBER) converts two numbers to complex double precision numbers.